### PR TITLE
Upgrade gem versions to modern ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.3.0
 script: "bundle exec rake spec SPEC_OPTS='--format documentation'"
 notifications:
   email: dean.wilson@gmail.com

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'rspec', '~> 3.1.0'
-gem 'puppet', '~> 3'
-gem 'rubocop', '~> 0.36.0', require: false
-gem 'puppetlabs_spec_helper', :require => false
+gem 'rspec', '~> 3.5.0'
+gem 'puppet', '~> 4.8.0', require: false
+gem 'rubocop', '~> 0.47.1', require: false
+gem 'puppetlabs_spec_helper', '1.2.2', :require => false
 gem 'json'
-gem 'rake'
+gem 'rake', '~> 12.0.0'


### PR DESCRIPTION
The move to rake 12.0 was causing issues with
`undefined method last_comment`. Bumping to these versions
makes everything move to the replacement function.